### PR TITLE
[Feature] - Support for Pokémon with three types

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -17,7 +17,7 @@ export class PokeroleItem extends Item {
 
     if (this.actor) {
       this.system.stab = this.system.type !== 'none' 
-          && [this.actor.system.type1, this.actor.system.type2].includes(this.system.type);
+          && [this.actor.system.type1, this.actor.system.type2, this.actor.system.type3].includes(this.system.type);
     }
   }
 

--- a/module/helpers/clash.mjs
+++ b/module/helpers/clash.mjs
@@ -1,4 +1,4 @@
-import { calcDualTypeMatchupScore, getLocalizedPainPenaltiesForSelect, POKEROLE } from "./config.mjs";
+import { calcTripleTypeMatchupScore, getLocalizedPainPenaltiesForSelect, POKEROLE } from "./config.mjs";
 import { getEffectivenessText, createSuccessRollMessageData } from "./roll.mjs";
 import { PokeroleActor } from "../documents/actor.mjs";
 
@@ -126,8 +126,8 @@ export async function showClashDialog(actor, actorToken, attacker, attackingMove
 }
 
 function calculateClashDamage(move, defender) {
-  let matchup = calcDualTypeMatchupScore(move.system.type,
-    defender.system.type1, defender.system.type2);
+  let matchup = calcTripleTypeMatchupScore(move.system.type,
+    defender.system.type1, defender.system.type2, defender.system.type3);
   let damage = Math.max(1 + matchup, 0);
   let html = '';
   let text = getEffectivenessText(matchup);

--- a/module/helpers/clash.mjs
+++ b/module/helpers/clash.mjs
@@ -1,4 +1,4 @@
-import { calcTripleTypeMatchupScore, getLocalizedPainPenaltiesForSelect, POKEROLE } from "./config.mjs";
+import { calcDualTypeMatchupScore, calcTripleTypeMatchupScore, getLocalizedPainPenaltiesForSelect, POKEROLE } from "./config.mjs";
 import { getEffectivenessText, createSuccessRollMessageData } from "./roll.mjs";
 import { PokeroleActor } from "../documents/actor.mjs";
 
@@ -126,8 +126,9 @@ export async function showClashDialog(actor, actorToken, attacker, attackingMove
 }
 
 function calculateClashDamage(move, defender) {
-  let matchup = calcTripleTypeMatchupScore(move.system.type,
-    defender.system.type1, defender.system.type2, defender.system.type3);
+  let matchup = defender.system.hasThirdType ? calcTripleTypeMatchupScore(move.system.type,
+    defender.system.type1, defender.system.type2, defender.system.type3)
+  :calcDualTypeMatchupScore(move.system.type, defender.system.type1, defender.system.type2);
   let damage = Math.max(1 + matchup, 0);
   let html = '';
   let text = getEffectivenessText(matchup);

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -362,6 +362,10 @@ export function calcDualTypeMatchupScore(attacking, defending1, defending2) {
   return calcTypeMatchupScore(attacking, defending1) + calcTypeMatchupScore(attacking, defending2);
 }
 
+export function calcTripleTypeMatchupScore(attacking, defending1, defending2, defending3) {
+  return calcTypeMatchupScore(attacking, defending1) + calcTypeMatchupScore(attacking, defending2) + calcTypeMatchupScore(attacking, defending3);
+}
+
 export function getTypeMatchups(defending) {
   return POKEROLE.typeMatchups[defending];
 }
@@ -394,6 +398,52 @@ export function getDualTypeMatchups(defending1, defending2) {
         break;
       case -2:
         matchups.doubleResist.push(attacking);
+        break;
+      case Number.NEGATIVE_INFINITY:
+        matchups.immune.push(attacking);
+        break;
+    }
+  }
+
+  return matchups;
+}
+/**
+ *
+ * @param {string} defending1 First type of the defender
+ * @param {string} defending2 Second type of the defender
+ * @param {string} defending3 Third type of the defender
+ * @returns {{weak: string[], doubleWeak: string[], tripleWeak: string[], resist: string[], doubleResist: string[], tripleResist: string[], immune: string[]}}
+ */
+export function getTripleTypeMatchups(defending1, defending2, defending3) {
+  let matchups = {
+    weak: [],
+    doubleWeak: [],
+    tripleWeak: [],
+    resist: [],
+    doubleResist: [],
+    tripleResist: [],
+    immune: []
+  };
+
+  for (const attacking of Object.keys(POKEROLE.typeMatchups)) {
+    switch (calcTripleTypeMatchupScore(attacking, defending1, defending2, defending3)) {
+      case 1:
+        matchups.weak.push(attacking);
+        break;
+      case 2:
+        matchups.doubleWeak.push(attacking);
+        break;
+      case 3:
+        matchups.tripleWeak.push(attacking);
+        break;
+      case -1:
+        matchups.resist.push(attacking);
+        break;
+      case -2:
+        matchups.doubleResist.push(attacking);
+        break;
+      case -3:
+        matchups.tripleResist.push(attacking);
         break;
       case Number.NEGATIVE_INFINITY:
         matchups.immune.push(attacking);

--- a/module/helpers/effects.mjs
+++ b/module/helpers/effects.mjs
@@ -281,6 +281,8 @@ export async function addAilmentWithDialog(actor, category) {
 function isActorResistantAgainstAilment(actor, ailment) {
   const type1 = POKEROLE.typeMatchups[actor.system.type1] ?? POKEROLE.typeMatchups.none;
   const type2 = POKEROLE.typeMatchups[actor.system.type2] ?? POKEROLE.typeMatchups.none;
+  const type3 = POKEROLE.typeMatchups[actor.system.type3] ?? POKEROLE.typeMatchups.none;
 
-  return type1.ailmentImmunities.includes(ailment) || type2.ailmentImmunities.includes(ailment);
+
+  return type1.ailmentImmunities.includes(ailment) || type2.ailmentImmunities.includes(ailment) || type3.ailmentImmunities.includes(ailment);
 }

--- a/module/helpers/effects.mjs
+++ b/module/helpers/effects.mjs
@@ -284,5 +284,7 @@ function isActorResistantAgainstAilment(actor, ailment) {
   const type3 = POKEROLE.typeMatchups[actor.system.type3] ?? POKEROLE.typeMatchups.none;
 
 
-  return type1.ailmentImmunities.includes(ailment) || type2.ailmentImmunities.includes(ailment) || type3.ailmentImmunities.includes(ailment);
+  return type1.ailmentImmunities.includes(ailment)
+      || type2.ailmentImmunities.includes(ailment)
+      || (type3.ailmentImmunities.includes(ailment) && actor.system.hasThirdType);
 }

--- a/module/helpers/roll.mjs
+++ b/module/helpers/roll.mjs
@@ -1,4 +1,9 @@
-import { calcTripleTypeMatchupScore, getLocalizedPainPenaltiesForSelect, POKEROLE } from "./config.mjs";
+import {
+  calcDualTypeMatchupScore,
+  calcTripleTypeMatchupScore,
+  getLocalizedPainPenaltiesForSelect,
+  POKEROLE
+} from "./config.mjs";
 import { bulkApplyHp, createHealMessage } from "./damage.mjs";
 
 /**
@@ -520,11 +525,15 @@ export async function rollDamage(item, actor, token) {
       damage = rollResult;
       damage = Math.max(Math.floor(damage * damageFactor), 1);
       damageBeforeEffectiveness = damage;
-      let effectiveness = calcTripleTypeMatchupScore(
+      let effectiveness = defender.system.hasThirdType ? calcTripleTypeMatchupScore(
         item.system.type,
         defender.system.type1,
         defender.system.type2,
           defender.system.type3
+      ) : calcDualTypeMatchupScore(
+          item.system.type,
+          defender.system.type1,
+          defender.system.type2
       );
 
       if (rollResult > 0) {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1,4 +1,4 @@
-import { getDualTypeMatchups, getLocalizedEntriesForSelect, getLocalizedType, getLocalizedTypesForSelect, POKEROLE } from "../helpers/config.mjs";
+import { getTripleTypeMatchups, getLocalizedEntriesForSelect, getLocalizedType, getLocalizedTypesForSelect, POKEROLE } from "../helpers/config.mjs";
 import { successRollAttributeDialog, successRollSkillDialog } from "../helpers/roll.mjs";
 import { addAilmentWithDialog } from "../helpers/effects.mjs";
 
@@ -61,18 +61,24 @@ export class PokeroleActorSheet extends ActorSheet {
     context.types = getLocalizedTypesForSelect();
 
     context.matchups = {};
-    const matchups = getDualTypeMatchups(context.system.type1, context.system.type2);
+    const matchups = getTripleTypeMatchups(context.system.type1, context.system.type2, context.system.type3);
     if (matchups.resist) {
       context.matchups.resist = matchups.resist.map(getLocalizedType).join(', ');
     }
     if (matchups.doubleResist) {
       context.matchups.doubleResist = matchups.doubleResist.map(getLocalizedType).join(', ');
     }
+    if (matchups.tripleResist) {
+      context.matchups.tripleResist = matchups.tripleResist.map(getLocalizedType).join(', ');
+    }
     if (matchups.weak) {
       context.matchups.weak = matchups.weak.map(getLocalizedType).join(', ');
     }
     if (matchups.doubleWeak) {
       context.matchups.doubleWeak = matchups.doubleWeak.map(getLocalizedType).join(', ');
+    }
+    if (matchups.tripleWeak) {
+      context.matchups.tripleWeak = matchups.tripleWeak.map(getLocalizedType).join(', ');
     }
     if (matchups.immune) {
       context.matchups.immune = matchups.immune.map(getLocalizedType).join(', ');

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1,4 +1,4 @@
-import { getTripleTypeMatchups, getLocalizedEntriesForSelect, getLocalizedType, getLocalizedTypesForSelect, POKEROLE } from "../helpers/config.mjs";
+import { getTripleTypeMatchups, getDualTypeMatchups, getLocalizedEntriesForSelect, getLocalizedType, getLocalizedTypesForSelect, POKEROLE } from "../helpers/config.mjs";
 import { successRollAttributeDialog, successRollSkillDialog } from "../helpers/roll.mjs";
 import { addAilmentWithDialog } from "../helpers/effects.mjs";
 
@@ -61,7 +61,9 @@ export class PokeroleActorSheet extends ActorSheet {
     context.types = getLocalizedTypesForSelect();
 
     context.matchups = {};
-    const matchups = getTripleTypeMatchups(context.system.type1, context.system.type2, context.system.type3);
+    const matchups = context.system.hasThirdType
+        ? getTripleTypeMatchups(context.system.type1, context.system.type2, context.system.type3)
+        : getDualTypeMatchups(context.system.type1, context.system.type2);
     if (matchups.resist) {
       context.matchups.resist = matchups.resist.map(getLocalizedType).join(', ');
     }
@@ -785,10 +787,11 @@ export class PokeroleActorSheet extends ActorSheet {
   }
 
   async _showSettings() {
-    const { baseHp, customInitiativeMod, recommendedRank, source } = this.actor.system;
+    const { baseHp, customInitiativeMod, hasThirdType, recommendedRank, source } = this.actor.system;
     const content = await renderTemplate(this.constructor.SETTINGS_TEMPLATE_PATH, {
       baseHp,
       customInitiativeMod,
+      hasThirdType,
       recommendedRank,
       source,
       ranks: this.constructor.getLocalizedRanks(),
@@ -812,6 +815,8 @@ export class PokeroleActorSheet extends ActorSheet {
     if (!result) return;
     const formElement = result[0].querySelector('form');
     const formData = new FormDataExtended(formElement).object;
+    if(!formData.hasThirdType) this.actor.system.type3 = "none"
+    console.log(this.actor.system.type3);
 
     this.actor.update(formData);
   }

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -66,11 +66,19 @@
   }
 
   .sidedata {
+    width: 250px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    input, select {
+      height: 22px;
+    }
+  }
+  .sidedata-thirdtype {
     width: 300px;
     display: flex;
     flex-direction: column;
     gap: 2px;
-
     input, select {
       height: 22px;
     }

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -66,7 +66,7 @@
   }
 
   .sidedata {
-    width: 250px;
+    width: 300px;
     display: flex;
     flex-direction: column;
     gap: 2px;

--- a/template.json
+++ b/template.json
@@ -144,6 +144,8 @@
       "pokedexDescription": "",
       "type1": "none",
       "type2": "none",
+      "hasThirdType": false,
+      "type3": "none",
       "height": 0,
       "weight": 0,
       "recommendedRank": "none",

--- a/templates/actor/actor-pokemon-sheet.html
+++ b/templates/actor/actor-pokemon-sheet.html
@@ -10,7 +10,8 @@
         <h1 class="charname">
           <input name="name" type="text" value="{{actor.name}}" placeholder="Name" />
         </h1>
-        <div class="sidedata">
+
+        <div {{#if system.hasThirdType}}class="sidedata-thirdtype"{{else}}class="sidedata"{{/if}}>
           <div class="species">
             <label for="system.pokedexId" class="resource-label">Pokédex</label>
             <input type="text" class="pokedex-num" name="system.pokedexId" value="{{system.pokedexId}}" placeholder="0"
@@ -33,12 +34,13 @@
               </select>
             </div>
 
+            {{#if system.hasThirdType}}
             <div class="type">
               <select name="system.type3" value="{{system.type3}}" data-dtype="String" class="type-select">
                 {{selectOptions types selected=system.type3}}
               </select>
             </div>
-
+            {{/if}}
           </div>
         </div>
       </div>

--- a/templates/actor/actor-pokemon-sheet.html
+++ b/templates/actor/actor-pokemon-sheet.html
@@ -32,6 +32,13 @@
                 {{selectOptions types selected=system.type2}}
               </select>
             </div>
+
+            <div class="type">
+              <select name="system.type3" value="{{system.type3}}" data-dtype="String" class="type-select">
+                {{selectOptions types selected=system.type3}}
+              </select>
+            </div>
+
           </div>
         </div>
       </div>
@@ -189,6 +196,12 @@
               <span>{{ matchups.doubleWeak }}</span>
             </li>
             {{/if}}
+            {{#if matchups.tripleWeak}}
+              <li>
+                <h4>Triple weaknesses</h4>
+                <span>{{ matchups.tripleWeak }}</span>
+              </li>
+            {{/if}}
             {{#if matchups.resist}}
             <li>
               <h4>Resistances</h4>
@@ -200,6 +213,12 @@
               <h4>Double resistances</h4>
               <span>{{ matchups.doubleResist }}</span>
             </li>
+            {{/if}}
+            {{#if matchups.tripleResist}}
+              <li>
+                <h4>Triple resistances</h4>
+                <span>{{ matchups.tripleResist }}</span>
+              </li>
             {{/if}}
             {{#if matchups.immune}}
             <li>

--- a/templates/actor/actor-settings.html
+++ b/templates/actor/actor-settings.html
@@ -4,6 +4,12 @@
     <input type="number" name="system.baseHp" value="{{baseHp}}" min="0" max="99" data-dtype="Number"/>
   </div>
   <div class="form-group">
+    <label for="system.hasThirdType">Triple Typing</label>
+      <input type="checkbox" name="system.hasThirdType" value="{{hasThirdType}}" data-dtype="Boolean"
+        {{#if hasThirdType}}checked{{/if}}
+      />
+  </div>
+  <div class="form-group">
     <label for="system.customInitiativeMod">Custom Initiative Bonus</label>
     <input type="number" name="system.customInitiativeMod" value="{{customInitiativeMod}}" data-dtype="Number"/>
   </div>


### PR DESCRIPTION
Reworked the actor sheets to support Pokémon with three types. The changes include:
- A modified layout to display three types properly
- Added functionality to automatically calculate triple resistances and triple weakness in damage calculations
- Added a setting for toggling third types in the Pokémon settings menu (off by default)

The functionality has been tested locally in the development environment, but is yet to be fully user-tested.

Feel free to close the request if these changes aren't worth adding to the system